### PR TITLE
Disable StrictMode on main render

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,5 @@
-import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+ReactDOM.createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
Disable `React.StrictMode` to avoid double render of Resium canvas.

With `StrictMode` enabled everything renders twice, causing two Cesium instances to be rendered. Both are mode fullscreen by my code, so one overlaps the other. When geometry is added, is is likely added to the first Cesium instance in the DOM, which is the one we can't see.

Disabling `StrictMode` fixes the issue, but is less than ideal for development.

See https://github.com/reearth/resium/issues/647 and others https://github.com/reearth/resium/issues?q=is:issue+strictmode